### PR TITLE
Tag list in JSON file

### DIFF
--- a/src/static/tag-list.json
+++ b/src/static/tag-list.json
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "Business",
+        "slug": "business",
+    },
+    {
+        "name": "Cloud",
+        "slug": "cloud",
+    },
+    {
+        "name": "Customer",
+        "slug": "customer",
+    },
+    {
+        "name": "Design",
+        "slug": "design",
+    },
+    {
+        "name": "Inventory",
+        "slug": "inventory",
+    },
+    {
+        "name": "Magento Software",
+        "slug": "magento-software",
+    },
+    {
+        "name": "Marketing",
+        "slug": "marketing",
+    },
+    {
+        "name": "Order",
+        "slug": "order",
+    },
+    {
+        "name": "Pricing",
+        "slug": "pricing",
+    },
+    {
+        "name": "Product",
+        "slug": "product",
+    },
+    {
+        "name": "Programming",
+        "slug": "programming",
+    },
+]


### PR DESCRIPTION
Created a JSON of potential tags using existing, added a couple more. 

Name is what displays in the generated site. Can use spaces, capitalize.
Slug is the tag to use in markdown files. No spaces, use dashes.

For https://github.com/jcalcaben/gatsby-glossary-app/issues/9