### PR TITLE
Add GA plugin to track site usage

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,5 +13,16 @@ module.exports = {
         path: `${__dirname}/src/`,
       },
     },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: "UA-66243208-3",
+        // Avoids sending pageview hits from custom paths
+        exclude: [],
+        sampleRate: 5,
+        siteSpeedSampleRate: 10,
+        cookieDomain: "example.com",
+      },
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.3.17",
     "gatsby-link": "^2.0.16",
+    "gatsby-plugin-google-analytics": "^2.0.18",
     "gatsby-plugin-react-helmet": "^3.0.12",
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-transformer-json": "^2.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,6 +4149,13 @@ gatsby-link@^2.0.16:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
+gatsby-plugin-google-analytics@^2.0.18:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.0.18.tgz#f56aa1d0fc65bbc2f902ce0bc25159ea2e571524"
+  integrity sha512-fW2WKo7onfxr9sVUCKKtDRUVqleVHBp9CMz7xVWnNpiM3+u4KgYWj7VzmjKPr00zgmp/AOEu1L7SUjYMDys0QA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 gatsby-plugin-page-creator@^2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.12.tgz#00a5103715881e141c81b68b670ad8fb06291b7d"


### PR DESCRIPTION
This adds Google Analytics plugin to the site.


Fixes https://github.com/jcalcaben/gatsby-glossary-app/issues/27