### PR TITLE
Fix query to sort terms on front page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,7 +8,7 @@ export default IndexPage
 
 export const query = graphql`
   {
-    allMarkdownRemark {
+    allMarkdownRemark(sort: { fields: [fields___slug] }) {
       edges {
         node {
           frontmatter {


### PR DESCRIPTION
Testing: Open front page, see sorted terms